### PR TITLE
Reference columns by name not position

### DIFF
--- a/tests/testthat/test-fn-Matrix.R
+++ b/tests/testthat/test-fn-Matrix.R
@@ -765,7 +765,7 @@ test_that("matrixset 'long' loop works", {
   mn_ref <- lapply(mn_ref, function(u) tidyr::unnest_longer(u, .rows))
   mn_ref <- lapply(mn_ref, function(u) tidyr::unnest_wider(u, .rows))
   mn_ref <- lapply(mn_ref, function(u) {
-    u <- u[, c(1,4,2,3)]
+    u <- u[, c("program", ".rows_id", "mean", "median")]
     colnames(u)[2] <- ".rowname"
     u
   })
@@ -790,7 +790,7 @@ test_that("matrixset 'long' loop works", {
   grmn_ref <- lapply(grmn_ref, function(u) tidyr::unnest_longer(u, .columns))
   grmn_ref <- lapply(grmn_ref, function(u) tidyr::unnest_wider(u, .columns))
   grmn_ref <- lapply(grmn_ref, function(u) {
-    u <- u[, c(1,2,5,3,4)]
+    u <- u[, c("teacher", "class", ".columns_id", "mean", "median")]
     colnames(u)[3] <- ".colname"
     u
   })
@@ -815,7 +815,7 @@ test_that("matrixset 'long' loop works", {
   mn_ref <- lapply(mn_ref, function(u) tidyr::unnest_longer(u, .rows))
   mn_ref <- lapply(mn_ref, function(u) tidyr::unnest_wider(u, .rows))
   mn_ref <- lapply(mn_ref, function(u) {
-    u <- u[, c(1,4,2,3)]
+    u <- u[, c("program", ".rows_id", "mn", "md")]
     colnames(u)[2] <- ".rowname"
     u
   })
@@ -840,7 +840,7 @@ test_that("matrixset 'long' loop works", {
   grmn_ref <- lapply(grmn_ref, function(u) tidyr::unnest_longer(u, .columns))
   grmn_ref <- lapply(grmn_ref, function(u) tidyr::unnest_wider(u, .columns))
   grmn_ref <- lapply(grmn_ref, function(u) {
-    u <- u[, c(1,2,5,3,4)]
+    u <- u[, c("teacher", "class", ".columns_id", "mn", "md")]
     colnames(u)[3] <- ".colname"
     u
   })
@@ -865,7 +865,7 @@ test_that("matrixset 'long' loop works", {
   mn_ref <- lapply(mn_ref, function(u) tidyr::unnest_wider(u, .rows))
   mn_ref <- lapply(mn_ref, function(u) tidyr::unnest(u, c(ct.name, ct)))
   mn_ref <- lapply(mn_ref, function(u) {
-    u <- u[, c(1,4,2,3)]
+    u <- u[, c("program", ".rows_id", "ct.name", "ct")]
     colnames(u)[2] <- ".rowname"
     u
   })
@@ -890,7 +890,7 @@ test_that("matrixset 'long' loop works", {
   grmn_ref <- lapply(grmn_ref, function(u) tidyr::unnest_wider(u, .columns))
   grmn_ref <- lapply(grmn_ref, function(u) tidyr::unnest(u, c(ct.name, ct)))
   grmn_ref <- lapply(grmn_ref, function(u) {
-    u <- u[, c(1,2,5,3,4)]
+    u <- u[, c("teacher", "class", ".columns_id", "ct.name", "ct")]
     colnames(u)[3] <- ".colname"
     u
   })
@@ -1108,7 +1108,7 @@ test_that("matrixset 'wide' loop works", {
   mn_ref <- lapply(mn_ref, function(u) tidyr::unnest_longer(u, .rows))
   mn_ref <- lapply(mn_ref, function(u) tidyr::unnest_wider(u, .rows))
   mn_ref <- lapply(mn_ref, function(u) {
-    u <- u[, c(1,4,2,3)]
+    u <- u[, c("program", ".rows_id", "mean", "median")]
     colnames(u)[2] <- ".rowname"
     u
   })
@@ -1133,7 +1133,7 @@ test_that("matrixset 'wide' loop works", {
   grmn_ref <- lapply(grmn_ref, function(u) tidyr::unnest_longer(u, .columns))
   grmn_ref <- lapply(grmn_ref, function(u) tidyr::unnest_wider(u, .columns))
   grmn_ref <- lapply(grmn_ref, function(u) {
-    u <- u[, c(1,2,5,3,4)]
+    u <- u[, c("teacher", "class", ".columns_id", "mean", "median")]
     colnames(u)[3] <- ".colname"
     u
   })
@@ -1158,7 +1158,7 @@ test_that("matrixset 'wide' loop works", {
   mn_ref <- lapply(mn_ref, function(u) tidyr::unnest_longer(u, .rows))
   mn_ref <- lapply(mn_ref, function(u) tidyr::unnest_wider(u, .rows))
   mn_ref <- lapply(mn_ref, function(u) {
-    u <- u[, c(1,4,2,3)]
+    u <- u[, c("program", ".rows_id", "mn", "md")]
     colnames(u)[2] <- ".rowname"
     u
   })
@@ -1183,7 +1183,7 @@ test_that("matrixset 'wide' loop works", {
   grmn_ref <- lapply(grmn_ref, function(u) tidyr::unnest_longer(u, .columns))
   grmn_ref <- lapply(grmn_ref, function(u) tidyr::unnest_wider(u, .columns))
   grmn_ref <- lapply(grmn_ref, function(u) {
-    u <- u[, c(1,2,5,3,4)]
+    u <- u[, c("teacher", "class", ".columns_id", "mn", "md")]
     colnames(u)[3] <- ".colname"
     u
   })

--- a/tests/testthat/test-fn.R
+++ b/tests/testthat/test-fn.R
@@ -991,7 +991,7 @@ test_that("matrixset 'long' loop works", {
   mn_ref <- lapply(mn_ref, function(u) tidyr::unnest_longer(u, .rows))
   mn_ref <- lapply(mn_ref, function(u) tidyr::unnest_wider(u, .rows))
   mn_ref <- lapply(mn_ref, function(u) {
-   u <- u[, c(1,4,2,3)]
+   u <- u[, c("program", ".rows_id", "mean", "median")]
    colnames(u)[2] <- ".rowname"
    u
   })
@@ -1016,7 +1016,7 @@ test_that("matrixset 'long' loop works", {
   grmn_ref <- lapply(grmn_ref, function(u) tidyr::unnest_longer(u, .columns))
   grmn_ref <- lapply(grmn_ref, function(u) tidyr::unnest_wider(u, .columns))
   grmn_ref <- lapply(grmn_ref, function(u) {
-    u <- u[, c(1,2,5,3,4)]
+    u <- u[, c("teacher", "class", ".columns_id", "mean", "median")]
     colnames(u)[3] <- ".colname"
     u
   })
@@ -1041,7 +1041,7 @@ test_that("matrixset 'long' loop works", {
   mn_ref <- lapply(mn_ref, function(u) tidyr::unnest_longer(u, .rows))
   mn_ref <- lapply(mn_ref, function(u) tidyr::unnest_wider(u, .rows))
   mn_ref <- lapply(mn_ref, function(u) {
-    u <- u[, c(1,4,2,3)]
+    u <- u[, c("program", ".rows_id", "mn", "md")]
     colnames(u)[2] <- ".rowname"
     u
   })
@@ -1066,7 +1066,7 @@ test_that("matrixset 'long' loop works", {
   grmn_ref <- lapply(grmn_ref, function(u) tidyr::unnest_longer(u, .columns))
   grmn_ref <- lapply(grmn_ref, function(u) tidyr::unnest_wider(u, .columns))
   grmn_ref <- lapply(grmn_ref, function(u) {
-    u <- u[, c(1,2,5,3,4)]
+    u <- u[, c("teacher", "class", ".columns_id", "mn", "md")]
     colnames(u)[3] <- ".colname"
     u
   })
@@ -1091,7 +1091,7 @@ test_that("matrixset 'long' loop works", {
   mn_ref <- lapply(mn_ref, function(u) tidyr::unnest_wider(u, .rows))
   mn_ref <- lapply(mn_ref, function(u) tidyr::unnest(u, c(ct.name, ct)))
   mn_ref <- lapply(mn_ref, function(u) {
-    u <- u[, c(1,4,2,3)]
+    u <- u[, c("program", ".rows_id", "ct.name", "ct")]
     colnames(u)[2] <- ".rowname"
     u
   })
@@ -1116,7 +1116,7 @@ test_that("matrixset 'long' loop works", {
   grmn_ref <- lapply(grmn_ref, function(u) tidyr::unnest_wider(u, .columns))
   grmn_ref <- lapply(grmn_ref, function(u) tidyr::unnest(u, c(ct.name, ct)))
   grmn_ref <- lapply(grmn_ref, function(u) {
-    u <- u[, c(1,2,5,3,4)]
+    u <- u[, c("teacher", "class", ".columns_id", "ct.name", "ct")]
     colnames(u)[3] <- ".colname"
     u
   })
@@ -1353,7 +1353,7 @@ test_that("matrixset 'wide' loop works", {
   mn_ref <- lapply(mn_ref, function(u) tidyr::unnest_longer(u, .rows))
   mn_ref <- lapply(mn_ref, function(u) tidyr::unnest_wider(u, .rows))
   mn_ref <- lapply(mn_ref, function(u) {
-    u <- u[, c(1,4,2,3)]
+    u <- u[, c("program", ".rows_id", "mean", "median")]
     colnames(u)[2] <- ".rowname"
     u
   })
@@ -1378,7 +1378,7 @@ test_that("matrixset 'wide' loop works", {
   grmn_ref <- lapply(grmn_ref, function(u) tidyr::unnest_longer(u, .columns))
   grmn_ref <- lapply(grmn_ref, function(u) tidyr::unnest_wider(u, .columns))
   grmn_ref <- lapply(grmn_ref, function(u) {
-    u <- u[, c(1,2,5,3,4)]
+    u <- u[, c("teacher", "class", ".columns_id", "mean", "median")]
     colnames(u)[3] <- ".colname"
     u
   })
@@ -1403,7 +1403,7 @@ test_that("matrixset 'wide' loop works", {
   mn_ref <- lapply(mn_ref, function(u) tidyr::unnest_longer(u, .rows))
   mn_ref <- lapply(mn_ref, function(u) tidyr::unnest_wider(u, .rows))
   mn_ref <- lapply(mn_ref, function(u) {
-    u <- u[, c(1,4,2,3)]
+    u <- u[, c("program", ".rows_id", "mn", "md")]
     colnames(u)[2] <- ".rowname"
     u
   })
@@ -1428,7 +1428,7 @@ test_that("matrixset 'wide' loop works", {
   grmn_ref <- lapply(grmn_ref, function(u) tidyr::unnest_longer(u, .columns))
   grmn_ref <- lapply(grmn_ref, function(u) tidyr::unnest_wider(u, .columns))
   grmn_ref <- lapply(grmn_ref, function(u) {
-    u <- u[, c(1,2,5,3,4)]
+    u <- u[, c("teacher", "class", ".columns_id", "mn", "md")]
     colnames(u)[3] <- ".colname"
     u
   })


### PR DESCRIPTION
We are planning a new tidyr release https://github.com/tidyverse/tidyr/issues/1622

In our reverse dependency checks, your package was flagged because the id column created by `unnest_longer()` is now placed to the left of the unnested column, and your package relied on the previous positional behavior.

This PR is a patch that should work with both CRAN and dev tidyr.

We are planning to release tidyr on Dec 17th, so if you could release a patch before then, that would be great. Thanks!